### PR TITLE
Add flappy environment - simple 2-row grid RL environment

### DIFF
--- a/FLAPPY_README.md
+++ b/FLAPPY_README.md
@@ -1,0 +1,103 @@
+# Flappy Environment
+
+A simple 2-row grid environment following the PufferLib tutorial for learning RL basics.
+
+## Environment Details
+- **Grid**: 2 rows x 10 columns
+- **Agent**: Moves UP (0) or DOWN (1) 
+- **Observation**: Agent's Y position (0 or 1)
+- **Reward**: 0 (simple case)
+- **Terminal**: True after each step
+
+## Setup
+
+### Using UV (Recommended)
+```bash
+# Install uv if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create virtual environment with Python 3.11.9
+uv venv --python 3.11.9
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+uv pip install -e .
+```
+
+### Alternative: Regular venv
+```bash
+# Create virtual environment
+python -m venv .venv
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+pip install -e .
+```
+
+## Training
+
+```bash
+# Activate virtual environment
+source .venv/bin/activate
+
+# Train the agent (1000 timesteps, CPU, adam optimizer)
+python -m pufferlib.pufferl train flappy --train.device cpu --train.total-timesteps 1000 --train.optimizer adam
+```
+
+**Expected Output:**
+- Training Speed: ~2.9K steps/second on CPU
+- Model Size: 323 parameters
+- Compatible with macOS Ventura 13.05+ and older PyTorch versions
+
+## Evaluation
+
+```bash
+# Evaluate with trained model (replace with your actual model path)
+puffer eval flappy --load-model-path experiments/175259232883/model_007813.pt
+
+# Or evaluate with random agent
+puffer eval flappy --render-mode ansi
+```
+
+**Expected Output:**
+```
++----------+
+|A.........|
+|..........|
++----------+
+```
+
+## Files Structure
+```
+pufferlib/
+├── environments/flappy/
+│   ├── __init__.py          # Module exports
+│   ├── environment.py       # Main environment implementation
+│   └── torch.py            # Neural network policy
+└── config/
+    └── flappy.ini          # Training configuration
+```
+
+## Configuration (flappy.ini)
+- `num_envs`: 2 (parallel environments)
+- `batch_size`: 128 (training batch size)
+- `optimizer`: adam (compatible with older systems)
+- `compile`: false (disabled for compatibility)
+
+## Troubleshooting
+
+### Common Issues:
+1. **"No config for env_name flappy"**: Make sure you're on the `flappy-environment` branch
+2. **Batch size errors**: Config is optimized for older macOS systems
+3. **PyTorch compatibility**: Uses adam optimizer instead of muon for older systems
+
+### Switch to flappy branch:
+```bash
+git checkout flappy-environment
+```
+
+Built following the [PufferLib tutorial](https://puffer.ai/docs.html) for creating simple RL environments. 

--- a/pufferlib/config/flappy.ini
+++ b/pufferlib/config/flappy.ini
@@ -1,0 +1,25 @@
+[base]
+package = flappy
+env_name = flappy
+policy_name = Policy
+rnn_name = None
+
+[vec]
+num_envs = 2
+num_workers = 1
+batch_size = 2
+backend = Serial
+
+[train]
+device = cpu
+total_timesteps = 1000
+batch_size = 128
+minibatch_size = 64
+learning_rate = 0.001
+update_epochs = 1
+compile = False
+optimizer = adam
+precision = float32
+
+[env]
+[policy]

--- a/pufferlib/environments/flappy/__init__.py
+++ b/pufferlib/environments/flappy/__init__.py
@@ -1,0 +1,8 @@
+from .environment import env_creator
+
+try:
+    import torch
+except ImportError:
+    pass
+else:
+    from .torch import Policy 

--- a/pufferlib/environments/flappy/environment.py
+++ b/pufferlib/environments/flappy/environment.py
@@ -1,0 +1,119 @@
+# Import the necessary libraries
+import gymnasium
+import numpy as np
+import pufferlib
+import functools
+
+def env_creator(name='flappy'):
+    return functools.partial(make, name)
+
+def make(name, render_mode='ansi', buf=None, seed=0):
+    '''Flappy environment creation function'''
+    return Flappy(render_mode=render_mode, buf=buf, seed=seed)
+
+# Define our actions as constants to make the code readable
+# For our simple game, we only need UP and DOWN
+UP = 0
+DOWN = 1
+
+# This is the main class for our environment
+# It inherits from pufferlib.PufferEnv
+class Flappy(pufferlib.PufferEnv):
+# This is the __init__ method we are filling in
+    def __init__(self, render_mode='ansi', buf=None, seed=0):
+        # First, we define our game's properties
+        self.grid_width = 10
+        self.grid_height = 2
+
+        # --- 1. What the agent can DO (Action Space) ---
+        # The agent has 2 possible actions: UP (0) and DOWN (1).
+        # We use spaces.Discrete for a fixed number of simple choices.
+        self.single_action_space = gymnasium.spaces.Discrete(2)
+
+        # --- 2. What the agent can SEE (Observation Space) ---
+        # To keep it simple, the agent will only observe its own Y position.
+        # Is it in the top row (0) or the bottom row (1)?
+        # This is a single number, so we use a Box space with a shape of (1,).
+        self.single_observation_space = gymnasium.spaces.Box(
+            low=0, high=self.grid_height - 1, shape=(1,), dtype=np.uint8)
+
+        # --- PufferLib Boilerplate ---
+        # These are required by PufferLib
+        self.render_mode = render_mode
+        self.num_agents = 1
+
+        # This line MUST be called after you define your spaces
+        super().__init__(buf)
+
+        # This will store the agent's current position
+        self.agent_pos = 0
+
+# This is the reset method we are filling in
+    def reset(self, seed=0):
+        # Set the agent's starting Y position to 0 (the top row)
+        self.agent_pos = 0
+
+        # The observation is the agent's position.
+        # We put it into the self.observations array that PufferLib uses.
+        self.observations[0] = [self.agent_pos]
+
+        # PufferLib requires this function to return the initial observations
+        # and an empty list for multi-agent compatibility.
+        return self.observations, []
+
+ # This is the step method we are filling in
+    def step(self, actions):
+        # The 'actions' variable contains the move from our agent's brain.
+        # For our single agent, this is actions[0].
+        action = actions[0]
+
+        # Move the agent's position
+        if action == UP:
+            self.agent_pos = 0  # Move to the top row
+        elif action == DOWN:
+            self.agent_pos = 1  # Move to the bottom row
+
+        # Check for game over conditions. In our simple game,
+        # the agent loses if it "moves" into the same spot it's already in.
+        # This is a simple way to simulate hitting a wall.
+        # A real Flappy Bird would have pipes to check against.
+        
+        # For this tutorial, we'll just end the game after one move.
+        # This is the simplest possible "game over" condition.
+        self.terminals[0] = True
+
+        # Assign a reward. Since the game ends no matter what,
+        # we'll give a neutral reward of 0 for this simple example.
+        # In a real game, you'd give -1 for hitting a wall.
+        self.rewards[0] = 0
+
+        # Update the observation with the agent's new position
+        self.observations[0] = [self.agent_pos]
+
+        # PufferLib requires this function to return these five values
+        # in this order. The info dictionary can be used for debugging.
+        info = {}
+        return self.observations, self.rewards, self.terminals, self.truncations, info
+
+
+    def render(self):
+        # Create a simple 10x2 grid as a list of lists
+        # '.' represents an empty space
+        grid = [
+            ['.' for _ in range(self.grid_width)],
+            ['.' for _ in range(self.grid_width)]
+        ]
+
+        # Place the agent 'A' in the grid at its current position
+        # For simplicity, we'll always draw the agent in the first column
+        grid[self.agent_pos][0] = 'A'
+
+        # Print the grid to the console
+        print('+' + '-' * self.grid_width + '+')
+        for row in grid:
+            print('|' + ''.join(row) + '|')
+        print('+' + '-' * self.grid_width + '+')
+
+    def close(self):
+        # This is for any cleanup when the environment is closed
+        pass 

--- a/pufferlib/environments/flappy/environment.py
+++ b/pufferlib/environments/flappy/environment.py
@@ -108,11 +108,14 @@ class Flappy(pufferlib.PufferEnv):
         # For simplicity, we'll always draw the agent in the first column
         grid[self.agent_pos][0] = 'A'
 
-        # Print the grid to the console
-        print('+' + '-' * self.grid_width + '+')
+        # Build the grid as a string and return it
+        output = []
+        output.append('+' + '-' * self.grid_width + '+')
         for row in grid:
-            print('|' + ''.join(row) + '|')
-        print('+' + '-' * self.grid_width + '+')
+            output.append('|' + ''.join(row) + '|')
+        output.append('+' + '-' * self.grid_width + '+')
+        
+        return '\n'.join(output)
 
     def close(self):
         # This is for any cleanup when the environment is closed

--- a/pufferlib/environments/flappy/torch.py
+++ b/pufferlib/environments/flappy/torch.py
@@ -1,0 +1,5 @@
+import pufferlib.models
+
+class Policy(pufferlib.models.Default):
+    def __init__(self, env, hidden_size=64):
+        super().__init__(env, hidden_size) 


### PR DESCRIPTION
- Created flappy environment following PufferLib docs tutorial
- Environment: 2-row grid where agent moves up/down
- Observation: agent position (0 or 1)
- Actions: UP (0) or DOWN (1)
- Reward: 0 (simple case)
- Terminal: true after each step
- Includes proper PufferLib structure with env_creator and Policy
- Config optimized for older macOS systems with CPU training
- Successfully trains with PuffeRL at ~2.9K steps/second