### PR TITLE
Drive tendril curriculum by angular-error EMA

### DIFF
--- a/pufferlib/ocean/tendril/binding.c
+++ b/pufferlib/ocean/tendril/binding.c
@@ -165,7 +165,7 @@ void c_reset(Tendril* env) {
     // Initialize curriculum system on first episode
     if (env->episode_count == 1) {
         env->curriculum_stage = 0;
-        env->hit_rate_ema = 0.0f;
+        env->ang_err_ema = 0.0f;
     }
     
     // Reset control state every episode (not just episode 1)
@@ -436,13 +436,15 @@ void c_step(Tendril* env) {
         
         // NEW: Update hit-rate EMA and advance curriculum
         const float EMA_ALPHA = 0.05f;  // Smoothing factor
-        bool success = (env->ep_hit == 1);
-        env->hit_rate_ema = (1.0f - EMA_ALPHA) * env->hit_rate_ema + EMA_ALPHA * (success ? 1.0f : 0.0f);
-        
-        // Advance curriculum when stable performance achieved
-        if (env->curriculum_stage < 4 && env->episode_count >= 500 && env->hit_rate_ema >= 0.10f) {
+        float ep_ang = (env->ep_steps > 0) ? (env->ep_ang_sum / env->ep_steps) : 0.0f;
+        float ep_ang_deg = ep_ang * 180.0f / (float)M_PI;
+        env->ang_err_ema = (1.0f - EMA_ALPHA) * env->ang_err_ema + EMA_ALPHA * ep_ang_deg;
+
+        // Advance curriculum when average angular error is below gate threshold
+        if (env->curriculum_stage < CURRICULUM_STAGES - 1 &&
+            env->episode_count >= 500 &&
+            env->ang_err_ema <= thr_deg) {
             env->curriculum_stage++;
-            env->hit_rate_ema = 0.0f;  // Reset to prevent instant leap to next stage
             #if !defined(NDEBUG)
             printf("[CURRICULUM] Advanced to stage %d (episode %d)\n", env->curriculum_stage, env->episode_count);
             #endif
@@ -1564,7 +1566,7 @@ static PyObject* vec_log(PyObject* self, PyObject* args) {
         float gate_hold_s = TENDRIL_HOLD_DURATIONS[stage];
         
         PyDict_SetItemString(log_dict, "curriculum_stage", PyFloat_FromDouble((double)stage));
-        PyDict_SetItemString(log_dict, "hit_rate_ema", PyFloat_FromDouble(env->hit_rate_ema));
+        PyDict_SetItemString(log_dict, "ang_err_ema", PyFloat_FromDouble(env->ang_err_ema));
         PyDict_SetItemString(log_dict, "gate_thr_deg", PyFloat_FromDouble(gate_thr_deg));
         PyDict_SetItemString(log_dict, "gate_hold_s", PyFloat_FromDouble(gate_hold_s));
         

--- a/pufferlib/ocean/tendril/tendril.h
+++ b/pufferlib/ocean/tendril/tendril.h
@@ -181,8 +181,11 @@ struct Client {
 };
 
 // Curriculum constants (shared across observations and rewards)
-static const float TENDRIL_THRESHOLD_DEG[5] = {12.0f, 10.0f, 8.0f, 6.0f, 5.0f};
-static const float TENDRIL_HOLD_DURATIONS[5] = {0.4f, 0.6f, 0.8f, 1.2f, 2.0f};
+// Added an easier initial stage with a wide angular gate and short hold
+// requirement to smooth early learning.
+static const float TENDRIL_THRESHOLD_DEG[6] = {25.0f, 12.0f, 10.0f, 8.0f, 6.0f, 5.0f};
+static const float TENDRIL_HOLD_DURATIONS[6] = {0.2f, 0.4f, 0.6f, 0.8f, 1.2f, 2.0f};
+#define CURRICULUM_STAGES 6
 
 typedef struct Tendril Tendril;
 struct Tendril {
@@ -253,12 +256,12 @@ struct Tendril {
     float prev_dist_mm;      // previous distance to target for progress reward
     
     // Per-environment curriculum (reviewer's fix)
-    uint64_t steps;          // per-env step counter 
+    uint64_t steps;          // per-env step counter
     double sched_total_steps; // steps per this env to reach full difficulty
-    
-    // NEW: Hit-rate based curriculum
-    int curriculum_stage;    // 0..4 curriculum progression
-    float hit_rate_ema;      // exponential moving average of success rate
+
+    // NEW: Angular-error based curriculum
+    int curriculum_stage;    // 0..CURRICULUM_STAGES-1 progression
+    float ang_err_ema;       // EMA of per-episode angular error (deg)
     int episode_count;       // total episodes for this environment
     
     // NEW: Action smoothing and tracking
@@ -613,7 +616,7 @@ static inline void init(Tendril* env) {
 
     // NEW: Initialize curriculum/stats defaults for all builds (expert fix)
     env->curriculum_stage = 0;
-    env->hit_rate_ema = 0.0f;
+    env->ang_err_ema = 0.0f;
     env->episode_count = 0;
     env->steps = 0;
     env->sched_total_steps = 0.0;  // Legacy telemetry compatibility


### PR DESCRIPTION
## Summary
- Ease initial curriculum by adding 25°/0.2 s threshold tier
- Progress stages using angular error EMA instead of hit rate
- Expose angular error EMA and gate thresholds in telemetry

## Testing
- `python - <<'PY'
import numpy as np
from pufferlib.ocean.tendril import tendril
env = tendril.Tendril(num_envs=1, render_mode=None)
obs,_=env.reset()
for _ in range(5):
    obs, rew, term, trunc, infos = env.step(np.zeros((1,3), dtype=np.float32))
print('info:', infos[0])
PY`
- `pytest tests/test_env_binding.py::test_env_binding -q` *(fails: ImportError: cannot import name 'binding' from 'pufferlib.ocean.breakout')*

------
https://chatgpt.com/codex/tasks/task_e_68a918e1f0608332928afad08ec7a75f