### PR TITLE
feat: add servo warmup flag

### DIFF
--- a/pufferlib/ocean/tendril/CHANGES.md
+++ b/pufferlib/ocean/tendril/CHANGES.md
@@ -428,4 +428,8 @@ const char* target_label;  // was: char* target_label
 - **Final Critical Patch**: 4 remaining linkage landmines eliminated ✅
 - **Total**: 23 expert-identified issues resolved ✅
 
+### Servo Warmup for Curriculum Training
+- Added build-time flag `TENDRIL_SERVO_WARMUP` to bypass backlash and limit penalties during early episodes.
+- `_apply_servo_plant` skips nonlinear dynamics when warmup is active and gradually restores them as hit-rate improves.
+
 The Tendril environment is now ready for production deployment with absolute confidence.

--- a/pufferlib/ocean/tendril/binding.c
+++ b/pufferlib/ocean/tendril/binding.c
@@ -73,6 +73,7 @@ static inline int sgnf(float x) { return (x > 0.f) - (x < 0.f); }
 static void _apply_servo_plant(struct Tendril* env, const float action01[3], float dt)
 {
     int saturated_any = 0;
+    float nonlin = env->servo_nonlinearity;
 
     // Push commands into latency queues and pull delayed cmds
     float delayed_cmd_deg_s[3];
@@ -92,44 +93,54 @@ static void _apply_servo_plant(struct Tendril* env, const float action01[3], flo
         float v_ref = (1.f - CMD_LPF_ALPHA) * env->cmd_filt_deg_s[j] + CMD_LPF_ALPHA * delayed_cmd_deg_s[j];
         env->cmd_filt_deg_s[j] = v_ref;
 
-        // 2) Deadband
-        if (fabsf(v_ref) < VEL_DEADBAND_DEG_S) v_ref = 0.f;
+        if (nonlin > 0.f) {
+            // 2) Deadband
+            if (fabsf(v_ref) < VEL_DEADBAND_DEG_S * nonlin) v_ref = 0.f;
 
-        // 3) Backlash: on direction flip, consume BACKLASH_DEG of "gap"
-        int sign_now = sgnf(v_ref);
-        if (sign_now != 0 && sign_now != env->sign_prev[j]) {
-            env->backlash_remain_deg[j] = BACKLASH_DEG;
-            env->sign_prev[j] = sign_now;
+            // 3) Backlash: on direction flip, consume BACKLASH_DEG of "gap"
+            int sign_now = sgnf(v_ref);
+            if (sign_now != 0 && sign_now != env->sign_prev[j]) {
+                env->backlash_remain_deg[j] = BACKLASH_DEG * nonlin;
+                env->sign_prev[j] = sign_now;
+            }
+            if (env->backlash_remain_deg[j] > 0.f && v_ref != 0.f) {
+                float consume = fminf(fabsf(v_ref) * dt, env->backlash_remain_deg[j]);
+                env->backlash_remain_deg[j] -= consume;
+                // while backlash remains, do not move the output shaft
+                v_ref = 0.f;
+            }
+
+            // 4) Acceleration limiting
+            float dv = v_ref - env->joint_vel_deg_s[j];
+            float dv_max = JOINT_ACC_MAX_DEG[j] * dt;
+            dv_max = dv_max * nonlin + 1e6f * (1.f - nonlin);
+            if (dv > dv_max) { dv = dv_max; saturated_any = 1; }
+            if (dv < -dv_max){ dv = -dv_max; saturated_any = 1; }
+            env->joint_vel_deg_s[j] += dv;
+
+            // 5) Damping (viscous)
+            env->joint_vel_deg_s[j] *= (1.f - DAMPING_PER_SEC * dt * nonlin);
+
+            // 6) Velocity saturation
+            float vlim = JOINT_VEL_MAX_DEG[j] * nonlin + 1e6f * (1.f - nonlin);
+            if (env->joint_vel_deg_s[j] > vlim) { env->joint_vel_deg_s[j] = vlim; saturated_any = 1; }
+            if (env->joint_vel_deg_s[j] < -vlim){ env->joint_vel_deg_s[j] = -vlim; saturated_any = 1; }
+        } else {
+            // Linear warmup mode: directly integrate filtered command
+            env->joint_vel_deg_s[j] = v_ref;
         }
-        if (env->backlash_remain_deg[j] > 0.f && v_ref != 0.f) {
-            float consume = fminf(fabsf(v_ref) * dt, env->backlash_remain_deg[j]);
-            env->backlash_remain_deg[j] -= consume;
-            // while backlash remains, do not move the output shaft
-            v_ref = 0.f;
-        }
 
-        // 4) Acceleration limiting
-        float dv = v_ref - env->joint_vel_deg_s[j];
-        float dv_max = JOINT_ACC_MAX_DEG[j] * dt;
-        if (dv > dv_max) { dv = dv_max; saturated_any = 1; }
-        if (dv < -dv_max){ dv = -dv_max; saturated_any = 1; }
-        env->joint_vel_deg_s[j] += dv;
-
-        // 5) Damping (viscous)
-        env->joint_vel_deg_s[j] *= (1.f - DAMPING_PER_SEC * dt);
-        // 6) Velocity saturation
-        if (env->joint_vel_deg_s[j] > JOINT_VEL_MAX_DEG[j]) { env->joint_vel_deg_s[j] = JOINT_VEL_MAX_DEG[j]; saturated_any = 1; }
-        if (env->joint_vel_deg_s[j] < -JOINT_VEL_MAX_DEG[j]){ env->joint_vel_deg_s[j] = -JOINT_VEL_MAX_DEG[j]; saturated_any = 1; }
-
-        // 7) Integrate angle and clamp to joint limits
+        // 7) Integrate angle and clamp to joint limits when fully nonlinear
         env->joint_deg[j] += env->joint_vel_deg_s[j] * dt;
-        if (env->joint_deg[j] < JOINT_MIN_DEG[j]) { env->joint_deg[j] = JOINT_MIN_DEG[j]; saturated_any = 1; env->joint_vel_deg_s[j] = 0.f; }
-        if (env->joint_deg[j] > JOINT_MAX_DEG[j]) { env->joint_deg[j] = JOINT_MAX_DEG[j]; saturated_any = 1; env->joint_vel_deg_s[j] = 0.f; }
+        if (nonlin >= 1.f) {
+            if (env->joint_deg[j] < JOINT_MIN_DEG[j]) { env->joint_deg[j] = JOINT_MIN_DEG[j]; saturated_any = 1; env->joint_vel_deg_s[j] = 0.f; }
+            if (env->joint_deg[j] > JOINT_MAX_DEG[j]) { env->joint_deg[j] = JOINT_MAX_DEG[j]; saturated_any = 1; env->joint_vel_deg_s[j] = 0.f; }
+        }
     }
 
-    env->servo_saturated_step = saturated_any;
+    env->servo_saturated_step = (nonlin >= 1.f) ? saturated_any : 0;
     env->servo_steps += 1;
-    if (saturated_any) env->limit_hits += 1;
+    if (nonlin >= 1.f && saturated_any) env->limit_hits += 1;
 
     // Export back to the rest of the sim (FK expects radians)
     for (int j = 0; j < 3; ++j) {
@@ -167,6 +178,13 @@ void c_reset(Tendril* env) {
         env->curriculum_stage = 0;
         env->hit_rate_ema = 0.0f;
     }
+
+#if TENDRIL_SERVO_WARMUP
+    if (env->servo_nonlinearity < 1.0f && env->hit_rate_ema >= SERVO_NONLINEAR_TARGET_HIT_RATE) {
+        env->servo_nonlinearity += SERVO_NONLINEAR_STEP;
+        if (env->servo_nonlinearity > 1.0f) env->servo_nonlinearity = 1.0f;
+    }
+#endif
     
     // Reset control state every episode (not just episode 1)
     memset(env->last_actions, 0, sizeof(env->last_actions));

--- a/pufferlib/ocean/tendril/tendril.h
+++ b/pufferlib/ocean/tendril/tendril.h
@@ -50,6 +50,19 @@ static const float JOINT_MAX_DEG[3]     = {175.f,120.f, 170.f};
 #define CMD_LATENCY_STEPS       2             // 2 * 10 ms = 20 ms latency
 #define DAMPING_PER_SEC         0.12f         // viscous damping (12%/s)
 
+// Optional servo warmup: set to 0 to always enable full dynamics
+#ifndef TENDRIL_SERVO_WARMUP
+#define TENDRIL_SERVO_WARMUP 1
+#endif
+
+// Hit-rate threshold and ramp step for re-enabling nonlinearity
+#ifndef SERVO_NONLINEAR_TARGET_HIT_RATE
+#define SERVO_NONLINEAR_TARGET_HIT_RATE 0.30f
+#endif
+#ifndef SERVO_NONLINEAR_STEP
+#define SERVO_NONLINEAR_STEP 0.25f
+#endif
+
 // HARDWARE-ACCURATE STL specifications (measured from actual files)
 #define BASE_WIDTH 60.0f      // Base.stl: 60×60×20mm (measured: -30 to +30)
 #define BASE_HEIGHT 60.0f
@@ -278,6 +291,9 @@ struct Tendril {
     float last_cmd_norm[3];       // last raw action [-1,1], for obs/debug
     int8_t sign_prev[3];          // previous command sign (-1,0,+1)
     float backlash_remain_deg[3]; // remaining backlash to consume [deg]
+
+    // Scale of servo nonlinearity [0=linear,1=full]
+    float servo_nonlinearity;
 
     // Simple fixed-latency queue per joint (command delay)
     float cmd_queue_deg_s[3][CMD_LATENCY_STEPS];
@@ -629,6 +645,13 @@ static inline void init(Tendril* env) {
         env->prev_joint_vel[i] = 0.0f;  // Previous velocities start at zero
         env->last_actions[i] = 0.0f;    // Previous actions start at zero
     }
+
+    // Servo nonlinearity disabled during warmup if configured
+#if TENDRIL_SERVO_WARMUP
+    env->servo_nonlinearity = 0.0f;
+#else
+    env->servo_nonlinearity = 1.0f;
+#endif
 }
 
 // Allocate memory for PufferLib interface


### PR DESCRIPTION
## Summary
- add optional servo warmup flag and runtime ramp based on hit rate
- scale servo plant nonlinearity to bypass backlash and limit penalties during warmup
- document servo warmup mode in changes log

## Testing
- `pytest tests/test_env_binding.py::test_env_binding -q` *(fails: cannot import breakout binding)*
- `gcc -fsyntax-only -I/usr/include/python3.11 -I/usr/lib/python3/dist-packages/numpy/core/include pufferlib/ocean/tendril/binding.c` *(fails: Python.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a918e62c648332a68113603c7e359e