### PR TITLE
Use byte flags for tendril termination arrays

### DIFF
--- a/pufferlib/ocean/tendril/binding.c
+++ b/pufferlib/ocean/tendril/binding.c
@@ -399,8 +399,8 @@ void c_step(Tendril* env) {
     bool stall_terminal = stall;  // Early termination for limit stalls
     bool timeout_truncation = (env->tick >= max_steps);
     
-    env->terminals[0] = success_terminal || stall_terminal;
-    env->truncations[0] = (!env->terminals[0] && timeout_truncation);
+    env->terminals[0] = (unsigned char)((success_terminal || stall_terminal) ? 1 : 0);
+    env->truncations[0] = (unsigned char)((!env->terminals[0] && timeout_truncation) ? 1 : 0);
     
     // Update observations
     compute_observations(env);
@@ -1169,8 +1169,8 @@ static PyObject* env_init(PyObject* self, PyObject* args) {
     env->observations = (float*)PyArray_DATA((PyArrayObject*)obs_arr);
     env->actions = (float*)PyArray_DATA((PyArrayObject*)act_arr);
     env->rewards = (float*)PyArray_DATA((PyArrayObject*)rew_arr);
-    env->terminals = (bool*)PyArray_DATA((PyArrayObject*)term_arr);
-    env->truncations = (bool*)PyArray_DATA((PyArrayObject*)trunc_arr);
+    env->terminals = (unsigned char*)PyArray_DATA((PyArrayObject*)term_arr);
+    env->truncations = (unsigned char*)PyArray_DATA((PyArrayObject*)trunc_arr);
     
     init(env);
     seed_rng(env, seed);
@@ -1422,8 +1422,8 @@ static PyObject* vec_init(PyObject* self, PyObject* args, PyObject* kwargs) {
         env->observations = &((float*)PyArray_DATA((PyArrayObject*)obs_arr))[i * 20]; // 20D obs
         env->actions = &((float*)PyArray_DATA((PyArrayObject*)act_arr))[i * 3];       // 3D actions  
         env->rewards = &((float*)PyArray_DATA((PyArrayObject*)rew_arr))[i];
-        env->terminals = &((bool*)PyArray_DATA((PyArrayObject*)term_arr))[i];
-        env->truncations = &((bool*)PyArray_DATA((PyArrayObject*)trunc_arr))[i];
+        env->terminals = &((unsigned char*)PyArray_DATA((PyArrayObject*)term_arr))[i];
+        env->truncations = &((unsigned char*)PyArray_DATA((PyArrayObject*)trunc_arr))[i];
         
         init(env);
         seed_rng(env, seed + i);  // Initialize per-env thread-safe RNG

--- a/pufferlib/ocean/tendril/tendril.h
+++ b/pufferlib/ocean/tendril/tendril.h
@@ -190,8 +190,8 @@ struct Tendril {
     float* observations;      // [joint_sin_cos(6), end_pos(3), target_pos(3), joint_vels(3), pointing_dir(3), angular_error(1), stability_timer(1)] = 20D
     float* actions;          // [velocity_setpoints_normalized(3)] = 3D (velocity commands in [-1,1])
     float* rewards;          // Reward signal
-    bool* terminals;         // Episode termination (bool to match PufferEnv)
-    bool* truncations;       // Episode truncation (bool to match PufferEnv)
+    unsigned char* terminals;         // Episode termination flag (0 or 1)
+    unsigned char* truncations;       // Episode truncation flag (0 or 1)
     Log log;                 // Performance logging
     Client* client;          // Rendering client
     
@@ -637,8 +637,8 @@ static inline void allocate(Tendril* env) {
     env->observations = (float*)calloc(20, sizeof(float));  // 20D observation (sin/cos angles + pointing + stability)
     env->actions = (float*)calloc(3, sizeof(float));        // 3D action
     env->rewards = (float*)calloc(1, sizeof(float));
-    env->terminals = (bool*)calloc(1, sizeof(bool));
-    env->truncations = (bool*)calloc(1, sizeof(bool));
+    env->terminals = (unsigned char*)calloc(1, sizeof(unsigned char));
+    env->truncations = (unsigned char*)calloc(1, sizeof(unsigned char));
 }
 
 // Free allocated memory


### PR DESCRIPTION
## Summary
- Use unsigned char buffers for tendril termination and truncation flags
- Update binding to write 0/1 flags and cast NumPy boolean arrays accordingly

## Testing
- `pytest tests/test_flatten.py::test_flatten -q` *(fails: ImportError: cannot import name 'flatten_structure')*

------
https://chatgpt.com/codex/tasks/task_e_68a918e4decc8332bd0e6980787d58dd